### PR TITLE
Add PostgreSQL 15 Compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,14 @@ WORKDIR /usr/src/app/
 
 COPY . /usr/src/app
 
-RUN lein do clean, deps
-
-RUN lein uberjar && \
-    cp target/sharkbait-standalone.jar .
-
-RUN ln -s "/usr/bin/java" "/bin/sharkbait"
+RUN lein do clean, deps && \
+    lein uberjar && \
+    cp target/sharkbait-standalone.jar . && \
+    mv sharkbait /bin/
 
 ENV CLASSPATH="$GROUPER_HOME/classes"
 
-ENTRYPOINT ["sharkbait", "-jar", "sharkbait-standalone.jar"]
+ENTRYPOINT ["sharkbait"]
 CMD ["--help"]
 
 ARG git_commit=unknown

--- a/project.clj
+++ b/project.clj
@@ -24,18 +24,17 @@
             [lein-cljfmt "0.8.0"]
             [jonase/eastwood "0.9.9"]
             [test2junit "1.4.2"]]
-  :dependencies [[edu.internet2.middleware.grouper/grouper "2.5.29"
+  :dependencies [[edu.internet2.middleware.grouper/grouper "2.5.68"
                   :exclusions [javax.transaction/jta
                                org.wso2.charon/org.wso2.charon.core
                                org.wso2.charon/org.wso2.charon.samples]]
                  [javax.transaction/jta "1.1"]
                  [honeysql "1.0.461"]
                  [korma "0.4.3"]
-                 [org.clojure/clojure "1.10.3"]
-                 [org.clojure/tools.logging "1.1.0"]
+                 [org.clojure/clojure "1.11.1"]
+                 [org.clojure/tools.logging "1.2.4"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/kameleon "3.0.6"]
-                 [postgresql "9.3-1102.jdbc41"]]
+                 [org.cyverse/kameleon "3.0.8"]]
   :main sharkbait.core
   :profiles {:eastwood {:resource-paths ["test-resources"]}
              :uberjar {:aot :all}})

--- a/sharkbait
+++ b/sharkbait
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+java -cp /opt/grouper/grouperWebapp/WEB-INF/classes:/usr/src/app/sharkbait-standalone.jar sharkbait.core "$@"


### PR DESCRIPTION
The JDBC driver in the previous version of Grouper that we were using was not compatible with PostgreSQL 15. To fix this, I upgraded to a more recent patch release of Grouper 2.5 and updated a few dependencies.

I ran into a problem when I tried to run Sharkbait. It was finding the configuration inside the uberjar rather than the ones that I wanted it to find, and that was causing an error. There's probably a better way to fix this, but I ended up fixing it by adding a wrapper script that sets the classpath so that the base configuration files in the file system are found first. The wrapper script actually improves the usability a bit, so I may just leave it this way.
